### PR TITLE
Map Notes creation ability

### DIFF
--- a/WME MapCommentGeometry.user.js
+++ b/WME MapCommentGeometry.user.js
@@ -299,7 +299,7 @@ See simplify.js by Volodymyr Agafonkin (https://github.com/mourner/simplify-js)
 	}
 
 	// Based on selected helper road modifies a map comment to precisely follow the road's geometry
-	function convertToLandmark(sel, NumSegments, s, conversion = { points: polyPoints, lastRightEq, lastLeftEq }, width = TheCommentWidth) {
+	function convertToLandmark(sel, NumSegments, s, conversion = { points: polyPoints, lastRightEq: prevRightEq, lastLeftEq: prevLeftEq }, width = TheCommentWidth) {
 		let i;
 		let leftPa; let rightPa; let leftPb; let rightPb;
 

--- a/WME MapCommentGeometry.user.js
+++ b/WME MapCommentGeometry.user.js
@@ -276,24 +276,31 @@ See simplify.js by Volodymyr Agafonkin (https://github.com/mourner/simplify-js)
 		console.log("WME MapCommentGeometry");
 	}
 
+	function getGeometryForSegments(segments, width) {
+		const conversion = {
+			points: null,
+			lastLeftEq: null,
+			lastRightEq: null,
+		};
+
+		for (let i = segments.length - 1; i >= 0; i--) {
+			const segment = segments[i];
+			convertToLandmark(segment, NaN, i, conversion, width);
+		}
+
+		return conversion.points;
+	}
+
 
 	// Process Map Comment Button
 	function doMapComment(ev) {
-		// let convertOK;
-		const foundSelectedSegment = false;
-		let sel;
-		let NumSegments;
-		polyPoints = null;
-
 		// 2013-10-20: Get comment width
 		const selCommentWidth = document.getElementById('CommentWidth');
-		TheCommentWidth = parseInt(selCommentWidth.options[selCommentWidth.selectedIndex].value, 10);
+		const width = parseInt(selCommentWidth.options[selCommentWidth.selectedIndex].value, 10);
 
-		setlastCommentWidth(TheCommentWidth);
+		setlastCommentWidth(width);
 
-		console.log(`Comment width: ${TheCommentWidth}`);
-
-		// Search for helper road. If found create or expand a Map Comment
+		console.log(`Comment width: ${width}`);
 
 		const f = W.selectionManager.getSelectedFeatures();
 
@@ -302,14 +309,8 @@ See simplify.js by Volodymyr Agafonkin (https://github.com/mourner/simplify-js)
 			return null;
 		}
 
-		NumSegments = f.length - 1;
-		for (let s = NumSegments; s >= 0; s--) {
-			sel = f[s]._wmeObject;
-
-			if (sel.type === 'segment') {
-				convertToLandmark(sel, NumSegments, s);
-			}
-		}
+		const segments = f.map((feature) => feature._wmeObject).filter((object) => object.type === 'segment');
+		polyPoints = getGeometryForSegments(segments, width);
 	}
 
 	// Based on selected helper road modifies a map comment to precisely follow the road's geometry

--- a/WME MapCommentGeometry.user.js
+++ b/WME MapCommentGeometry.user.js
@@ -313,7 +313,7 @@ See simplify.js by Volodymyr Agafonkin (https://github.com/mourner/simplify-js)
 	}
 
 	// Based on selected helper road modifies a map comment to precisely follow the road's geometry
-	function convertToLandmark(sel, NumSegments, s) {
+	function convertToLandmark(sel, NumSegments, s, conversion = { points: polyPoints, lastRightEq, lastLeftEq }, width = TheCommentWidth) {
 		let i;
 		let leftPa; let rightPa; let leftPb; let rightPb;
 
@@ -332,7 +332,7 @@ See simplify.js by Volodymyr Agafonkin (https://github.com/mourner/simplify-js)
 		for (i = first; i < streetVertices.length - 1; i++) {
 			const pa = streetVertices[i];
 			const pb = streetVertices[i + 1];
-			const scale = (pa.distanceTo(pb) + TheCommentWidth) / pa.distanceTo(pb);
+			const scale = (pa.distanceTo(pb) + width) / pa.distanceTo(pb);
 			leftPa = pa.clone();
 			leftPa.resize(scale, pb, 1);
 			rightPa = leftPa.clone();
@@ -352,43 +352,43 @@ See simplify.js by Volodymyr Agafonkin (https://github.com/mourner/simplify-js)
 				x1: rightPa.x, y1: rightPa.y, x2: rightPb.x, y2: rightPb.y
 			});
 
-			if (polyPoints === null) polyPoints = [leftPa, rightPa];
+			if (conversion.points === null) conversion.points = [leftPa, rightPa];
 			else {
-				const li = intersectX(leftEq, prevLeftEq);
-				const ri = intersectX(rightEq, prevRightEq);
+				const li = intersectX(leftEq, conversion.lastLeftEq);
+				const ri = intersectX(rightEq, conversion.lastRightEq);
 				if (li && ri) {
 					// 2013-10-17: Is point outside comment?
 					if (i >= firstStreetVerticeOutside) {
-						polyPoints.unshift(li);
-						polyPoints.push(ri);
+						conversion.points.unshift(li);
+						conversion.points.push(ri);
 					}
 				} else {
 					// 2013-10-17: Is point outside comment?
 					if (i >= firstStreetVerticeOutside) {
-						polyPoints.unshift(leftPb.clone());
-						polyPoints.push(rightPb.clone());
+						conversion.points.unshift(leftPb.clone());
+						conversion.points.push(rightPb.clone());
 					}
 				}
 			}
 
-			prevLeftEq = leftEq;
-			prevRightEq = rightEq;
+			conversion.lastLeftEq = leftEq;
+			conversion.lastRightEq = rightEq;
 
 			console.log(`Point:${leftPb}  ${rightPb}`);
 		}
 
-		polyPoints.push(rightPb);
-		polyPoints.push(leftPb);
+		conversion.points.push(rightPb);
+		conversion.points.push(leftPb);
 
 		// YUL_: Add the first point at the end of the array to close the shape!
 		// YUL_: When creating a comment or other polygon, WME will automatically do this, but since we are modifying an existing Map Comment, we must do it here!
 		if (s==0) {
-			polyPoints.push(polyPoints[0]);
+			conversion.points.push(conversion.points[0]);
 			// YUL_: At this point we have the shape we need, and have to convert the existing map comment into that shape.
 			console.log("WME Map Comment polygon: done");
 		}
 
-		return true;
+		return conversion.points;
   }
 
 	function getEquation(segment) {


### PR DESCRIPTION
# Summary
This PR introduces a refactor to improve code isolation and a new feature for streamlined map note creation.

# Refactor
Updated the `convertToLandmark` function to work exclusively with scoped variables, avoiding reliance on global variables.

# New Features
- Integrated a custom library for streamlined map note creation:
    - Eliminates the need for multiple clicks to create a map note with the road's geometry.
    - Automatically selects the created map note.
- Removed the obsolete button in the note's edit panel.
- Renamed the button in the road's edit panel to reflect the automatic map note creation functionality.
