### PR TITLE
Allow using existing map comments

### DIFF
--- a/WME MapCommentGeometry.user.js
+++ b/WME MapCommentGeometry.user.js
@@ -249,18 +249,18 @@ See simplify.js by Volodymyr Agafonkin (https://github.com/mourner/simplify-js)
 		return mapComment;
 	}
 
-	function updateCommentGeometry(points){
-		if (WazeWrap.hasMapCommentSelected())
-		{
-			let model = WazeWrap.getSelectedDataModelObjects()[0];
-
-			center = model.getOLGeometry().getCentroid();
-
-			let newerGeo = getShapeWKT(points);
-			newerGeo = W.userscripts.toGeoJSONGeometry(newerGeo);
-			let UO = require("Waze/Action/UpdateObject");
-			W.model.actionManager.add(new UO(model, { geoJSONGeometry: newerGeo }));
+	function updateCommentGeometry(points, mapComment) {
+		if (!mapComment) {
+			if (!WazeWrap.hasMapCommentSelected()) return;
+			mapComment = WazeWrap.getSelectedDataModelObjects()[0];
 		}
+
+		center = mapComment.getOLGeometry().getCentroid();
+
+		let newerGeo = getShapeWKT(points);
+		newerGeo = W.userscripts.toGeoJSONGeometry(newerGeo);
+		let UO = require("Waze/Action/UpdateObject");
+		W.model.actionManager.add(new UO(mapComment, { geoJSONGeometry: newerGeo }));
 	}
 
 	function createLCamera(){ updateCommentGeometry(CameraLeftPoints); }

--- a/WME MapCommentGeometry.user.js
+++ b/WME MapCommentGeometry.user.js
@@ -320,6 +320,13 @@ See simplify.js by Volodymyr Agafonkin (https://github.com/mourner/simplify-js)
 
 		// Add button
 		const createMapNoteBtn = $(`<wz-button style="--space-button-text: 100%;" size="sm" color="text">${getString(idMapCommentGeo)}</wz-button>`);
+		createMapNoteBtn.click((e) => {
+			e.target.blur();
+			createComment(getGeometryOfSelection()).then((mapComment) => {
+				W.selectionManager.unselectAll();
+				W.selectionManager.selectFeatures([mapComment.getID()]);
+			});
+		});
 		createMapNoteBtn.click((e) => e.target.blur());
 		createMapNoteBtn.click(doMapComment);
 
@@ -367,30 +374,26 @@ See simplify.js by Volodymyr Agafonkin (https://github.com/mourner/simplify-js)
 		return conversion.points;
 	}
 
-
-	// Process Map Comment Button
-	function doMapComment(ev) {
-		// 2013-10-20: Get comment width
-		const selCommentWidth = document.getElementById('CommentWidth');
-		const width = parseInt(selCommentWidth.value, 10);
-
-		setlastCommentWidth(width);
+	function getGeometryOfSelection(width) {
+		if (!width) {
+			const selCommentWidth = document.getElementById('CommentWidth');
+			width = parseInt(selCommentWidth.value, 10);
+			setlastCommentWidth(width);
+		}
 
 		console.log(`Comment width: ${width}`);
 
-		const f = W.selectionManager.getSelectedFeatures();
-
-		if (f.length === 0) {
+		const selectedFeatures = W.selectionManager.getSelectedFeatures();
+		if (selectedFeatures.length === 0) {
 			console.error('No road selected!');
 			return null;
 		}
 
-		const segments = f.map((feature) => feature._wmeObject).filter((object) => object.type === 'segment');
+		const segments = selectedFeatures
+			.map((feature) => feature._wmeObject)
+			.filter((object) => object.type === 'segment');
 
-		createComment(getGeometryForSegments(segments, width)).then((mapComment) => {
-			W.selectionManager.unselectAll();
-			W.selectionManager.selectFeatures([mapComment.getID()]);
-		});
+		return getGeometryForSegments(segments, width);
 	}
 
 	// Based on selected helper road modifies a map comment to precisely follow the road's geometry


### PR DESCRIPTION
# Summary
In a previous pull request, I added the ability to directly create map notes on segments. This removed the need to manually create a map note but also removed the ability to reuse existing map comments whenever needed. This pull request solves this.

# New Features
I added an additional button named "Use Existing" to the "Create Note" button, which allows you to select a map note to use. The "Create Note" button was renamed "Create New" for clarity.

# Refactor
In addition, refactored and decoupled a few functions, like `getShapeWKT` and `updateCommentGeometry`.

Now, each of these functions does only what they were intended to do:
- `updateCommentGeometry` – Updates a specific (or selected) map note's geometry to whatever geometry is given.
- `getShapeWKT` – responsible for accepting a shape and resolving to the actual geometry which then can be used for `updateCommentGeometry`, or elsewhere if ever needed.

# Video
[Watch on YouTube](https://youtu.be/0MsiMqvLjxs)