### PR TITLE
Replace WS libraries, Add "Infer" option for width selection

### DIFF
--- a/WME MapCommentGeometry.user.js
+++ b/WME MapCommentGeometry.user.js
@@ -53,7 +53,7 @@ See simplify.js by Volodymyr Agafonkin (https://github.com/mourner/simplify-js)
 
 (async function() {
 	await SDK_INITIALIZED;
-	const UPDATE_NOTES = 'Added ability to create map comment shapes';
+	const UPDATE_NOTES = 'Added ability to infer width from selected segment';
 	const SCRIPT_NAME = GM_info.script.name;
 	const SCRIPT_VERSION = GM_info.script.version;
 	const idTitle = 0;

--- a/WME MapCommentGeometry.user.js
+++ b/WME MapCommentGeometry.user.js
@@ -6,7 +6,7 @@
 // @exclude			*://*.waze.com/user/editor*
 // @grant 			none
 // @require			https://greasyfork.org/scripts/24851-wazewrap/code/WazeWrap.js
-// @require			https://davidsl4.github.io/WMEScripts/lib/map-comments-polyfill.js
+// @require			http://davidsl4.github.io/WMEScripts/lib/wme-sdk-plus.js
 // @require			https://cdn.jsdelivr.net/npm/@turf/turf@7/turf.min.js
 // @downloadURL		https://raw.githubusercontent.com/YULWaze/WME-MapCommentGeometry/main/WME%20MapCommentGeometry.user.js
 // @updateURL		https://raw.githubusercontent.com/YULWaze/WME-MapCommentGeometry/main/WME%20MapCommentGeometry.user.js
@@ -60,6 +60,7 @@ See simplify.js by Volodymyr Agafonkin (https://github.com/mourner/simplify-js)
 	const idNewMapComment = 1;
 	const idExistingMapComment = 2;
 	const wmeSdk = getWmeSdk({ scriptId: 'wme-map-comment-geometry', scriptName: 'WME Map Comment Geometry' });
+	initWmeSdkPlus(wmeSdk);
 
 	const CameraLeftPoints = [[11,6],[-4,6],[-4,3],[-11,6],[-11,-6],[-4,-3],[-4,-6],[11,-6]];
 	const CameraRightPoints = [[-11,6],[4,6],[4,3],[11,6],[11,-6],[4,-3],[4,-6],[-11,-6]];
@@ -231,12 +232,9 @@ See simplify.js by Volodymyr Agafonkin (https://github.com/mourner/simplify-js)
 	}
 
 	async function createComment(geoJSONGeometry) {
-		let CO = require("Waze/Action/CreateObject");
-		const mapComment = await WS.MapNotes.createNote({
+		return wmeSdk.DataModel.MapComments.addMapComment({
 			geoJSONGeometry,
 		});
-		W.model.actionManager.add(new CO(mapComment, W.model.mapComments)); // CO accepts two arguments: entity and repository
-		return mapComment;
 	}
 
 	function updateCommentGeometry(geoJSONGeometry, mapComment) {


### PR DESCRIPTION
# WS Libraries -> WME SDK+
The WS libraries I developed previously worked, but they all shared large pieces of code and it became harder to maintain. I'm working on a new extension library called WME SDK Plus, which is intended to extend the WME SDK objects and add new functionality to it. It should be compatible with future WME SDK releases, and hopefully, it'll become obsolete (once Waze releases a function that exists in this extension library, it'll cease to "patch" it and instead will use native implementation).

# Infer width option
It'll calculate the average width out of all segments and will use it for the geometry.