### PR TITLE
fix: compatibility with WME v2.287-5

### DIFF
--- a/WME MapCommentGeometry.user.js
+++ b/WME MapCommentGeometry.user.js
@@ -980,8 +980,18 @@ See simplify.js by Volodymyr Agafonkin (https://github.com/mourner/simplify-js)
 
     intLanguageStrings();
 
-    W.selectionManager.events.register("selectionchanged", null, addWMESelectSegmentbutton);
-    W.selectionManager.events.register("selectionchanged", null, addControlsToMapCommentEditPanel);
+    const addFeatureEditorOpenedHandler = (featureType, handler) => {
+      wmeSdk.Events.on({
+        eventName: "wme-feature-editor-opened",
+        eventHandler: (e) => {
+          if (e.featureType !== featureType) return;
+          handler(e);
+        }
+      });
+    }
+
+    addFeatureEditorOpenedHandler('segment', addWMESelectSegmentbutton);
+    addFeatureEditorOpenedHandler('mapComment', addControlsToMapCommentEditPanel);
   }
 
   WMEMapCommentGeometry_bootstrap();


### PR DESCRIPTION
# The Issue

The new WME version defers UI rendering, which occurs after the "selectionchanged" event is triggered by the Selection Manager. This caused the DOM element selector for the editor panel (more specifically, this [line of code](https://github.com/davidsl4/WME-MapCommentGeometry/blob/5ce822b309218820aa6636f2373cf4d825543c2f/WME%20MapCommentGeometry.user.js#L732)) to return no elements.

# The solution
The WME SDK provides an "[wme-feature-editor-opened](https://www.waze.com/editor/sdk/interfaces/index.SDK.SdkEvents.html#wme-feature-editor-opened)" event, which is fired when the actual editor panel is opened and is ready. This event is a safe point of injection because we are sure that at this point the panel is rendered. 

This event also provides a few other benefits:

1. It uses the WME SDK – That means it is officially supported by Waze and won't be broken in future releases.
2. The event also indicates what type of feature the panel is rendered for (e.g., "segment", or "mapComment") – It allows us to trigger only the relevant event handler for the specific type of feature selected. We are no longer triggering the map comment handler for segments and vice versa.