### PR TITLE
feat: improve UI of segment's edit panel

### DIFF
--- a/WME MapCommentGeometry.user.js
+++ b/WME MapCommentGeometry.user.js
@@ -630,11 +630,9 @@ See simplify.js by Volodymyr Agafonkin (https://github.com/mourner/simplify-js)
 
       // Add MapCommentGeo section
       const rootContainer = $('<section id="MapCommentGeo" />');
-      rootContainer.append($('<div class="form-group" />')); // add an empty form group just for the margin above
 
       // Add comment width to section
-      const mapNoteWidthContainer = $('<div class="form-group" />');
-      mapNoteWidthContainer.append($("<wz-label>Element Width</wz-label>"));
+      rootContainer.append($("<wz-label>Element Width</wz-label>"));
       const mapNoteWidthControls = $('<div style="display: flex; flex-wrap: wrap; gap: 4px 12px;" />');
       mapNoteWidthControls.append(selCommentWidth);
 
@@ -726,8 +724,7 @@ See simplify.js by Volodymyr Agafonkin (https://github.com/mourner/simplify-js)
         }, getFeatureGeometryOptions('permanentHazard.schoolZone')),
       );
 
-      mapNoteWidthContainer.append(mapNoteWidthControls);
-      rootContainer.append(mapNoteWidthContainer);
+      rootContainer.append(mapNoteWidthControls);
 
       $("#segment-edit-general").append(rootContainer);
 

--- a/WME MapCommentGeometry.user.js
+++ b/WME MapCommentGeometry.user.js
@@ -629,7 +629,7 @@ See simplify.js by Volodymyr Agafonkin (https://github.com/mourner/simplify-js)
       selCommentWidth[0].shadowRoot.adoptedStyleSheets.push(selCommentWidthStyles);
 
       // Add MapCommentGeo section
-      const rootContainer = $('<section id="MapCommentGeo" />');
+      const rootContainer = $('<div id="MapCommentGeo" />');
 
       // Add comment width to section
       rootContainer.append($("<wz-label>Element Width</wz-label>"));


### PR DESCRIPTION
# Motivation

The existing UI was too spacious compared to other elements of Waze's UI. It also used semantic HTML incorrectly, and when it was unnecessary.

# Research

WME integrates gaps into the editor panel using flexbox, which means all elements inside that flexbox are spaced evenly, and we don't need extra padding or margin.

# Changes

1. Remove the unnecessary containers used for spacing, simplifying the HTML tree. Remove classes that add extra spacing and are intended for other parts of the UI.
2. Replace the incorrect semantic HTML container (`section`) with a non-semantic HTML container (`div`).