### PR TITLE
feat: render the editor feature panels on script load

### DIFF
--- a/WME MapCommentGeometry.user.js
+++ b/WME MapCommentGeometry.user.js
@@ -989,6 +989,14 @@ See simplify.js by Volodymyr Agafonkin (https://github.com/mourner/simplify-js)
 
     addFeatureEditorOpenedHandler('segment', addWMESelectSegmentbutton);
     addFeatureEditorOpenedHandler('mapComment', addControlsToMapCommentEditPanel);
+    switch (wmeSdk.Editing.getSelection()?.objectType) {
+      case "segment":
+        addWMESelectSegmentbutton();
+        break;
+      case "mapComment":
+        addControlsToMapCommentEditPanel();
+        break;
+    }
   }
 
   WMEMapCommentGeometry_bootstrap();


### PR DESCRIPTION
### Description

This pull request enables rendering of the custom feature editor panels (for segments and map comments) when the script loads, which usually occurs on WME load. This means that if the WME loads with a selection (from a permalink), the custom panels will be shown without the features being re-selected on the map.

It also serves as a temporary workaround for #15. Simply select the segment, create a permalink, and reload the WME. The segments will be selected, the event will fire for them, and the script will render the panels.