### PR TITLE
fix: multi-selection controls using new WME SDK+

### DIFF
--- a/WME MapCommentGeometry.user.js
+++ b/WME MapCommentGeometry.user.js
@@ -6,7 +6,7 @@
 // @exclude			*://*.waze.com/user/editor*
 // @grant 			none
 // @require			https://greasyfork.org/scripts/24851-wazewrap/code/WazeWrap.js
-// @require			https://cdn.jsdelivr.net/gh/WazeSpace/wme-sdk-plus@v1/wme-sdk-plus.js
+// @require			https://cdn.jsdelivr.net/gh/TheEditorX/wme-sdk-plus@1.2/wme-sdk-plus.js
 // @require			https://cdn.jsdelivr.net/npm/@turf/turf@7/turf.min.js
 // @downloadURL		https://raw.githubusercontent.com/YULWaze/WME-MapCommentGeometry/main/WME%20MapCommentGeometry.user.js
 // @updateURL		https://raw.githubusercontent.com/YULWaze/WME-MapCommentGeometry/main/WME%20MapCommentGeometry.user.js
@@ -979,7 +979,7 @@ See simplify.js by Volodymyr Agafonkin (https://github.com/mourner/simplify-js)
 
     const addFeatureEditorOpenedHandler = (featureType, handler) => {
       wmeSdk.Events.on({
-        eventName: "wme-feature-editor-opened",
+        eventName: "wme-feature-editor-rendered",
         eventHandler: (e) => {
           if (e.featureType !== featureType) return;
           handler(e);


### PR DESCRIPTION
## Summary

With the transition to using the SDK method to be notified about selection changes and when the editor panel is ready (2dc3488), we actually introduced a new bug that prevented us from using the script with multiple segments as we used to do. The cause for this bug is Waze's implementation of the event "wme-feature-editor-opened", and it seems to do what it declares it is for, but it is not sufficient for us. In summary, this event is triggered only once when the selection type is changed and the feature editor is rendered. It won't trigger again for subsequent selection changes of the same type.

WME SDK+ introduces a new Events module we can now leverage, as it provides a new event "wme-feature-editor-rendered", which is actually triggered every time the editor feature is rendered.

## Alternatives

We could use the [`wme-selection-changed`](https://www.waze.com/editor/sdk/interfaces/index.SDK.SdkEvents.html#wme-selection-changed) event that triggers when the selection changes. It is the same event the WME depends on to cause the feature editor panel to re-render. However, it is insufficient for us since at the time this event triggers, the feature editor panel is still not updated. We could defer our handler by X time and it will probably be called after the feature editor panel is updated, but it adds an artificial delay, which might also be inaccurate and will fail to be called after the editor is updated.

## Linked Issues

This pull request closes #15 and probably #20 as well. Although, on #20, I've seen some other changes, so it might be worth checking with the author before we close it.