### PR TITLE
fix: inference for non-drivable segments

### DIFF
--- a/WME MapCommentGeometry.user.js
+++ b/WME MapCommentGeometry.user.js
@@ -855,10 +855,10 @@ See simplify.js by Volodymyr Agafonkin (https://github.com/mourner/simplify-js)
       }
 
       const segmentAddress = wmeSdk.DataModel.Segments.getAddress({ segmentId });
-      const defaultLaneWidth =
-        (segmentAddress.country.defaultLaneWidthPerRoadType
-          ? segmentAddress.country.defaultLaneWidthPerRoadType[segment.roadType]
-          : 330) / 100;
+      const defaultLaneWidth = (
+        segmentAddress.country.defaultLaneWidthPerRoadType?.[segment.roadType]
+        ?? 330
+      ) / 100;
 
       const averageNumberOfLanes =
         ((segment.fromLanesInfo?.numberOfLanes || 1) + (segment.toLanesInfo?.numberOfLanes || 1)) / 2;


### PR DESCRIPTION
## Summary

This pull request updates the `getSegmentWidth` function with extra guards that ensure we always get a width for a segment. It fixes the issue when a non-drivable segment doesn't have lanes info (which makes sense) and the country object doesn't have a width for that segment's road type (because it is not a road).

## Changes

Optional chaining is to the rescue! By leveraging optional chaining, not only do I make the code more readable, but I also add a guard for road types without a default value, ensuring we will always have some value to work with. Previously, it was reserved for cases when the country had no default values for any road type (when the `defaultLaneWidthPerRoadType` property was undefined or null).

## Related Issues

This pull request fixes #19.